### PR TITLE
Keep library sources after the build for debug purposes

### DIFF
--- a/CMake/Dependencies/libkvsCommonLws-CMakeLists.txt
+++ b/CMake/Dependencies/libkvsCommonLws-CMakeLists.txt
@@ -4,10 +4,14 @@ project(libkvsCommonLws-download NONE)
 
 include(ExternalProject)
 
+# Specify a source directory for the external project
+set(SOURCE_DIR ${OPEN_SRC_INSTALL_PREFIX}/downloaded_source/libkvsCommonLws)
+
 ExternalProject_Add(libkvsCommonLws-download
     GIT_REPOSITORY    https://github.com/awslabs/amazon-kinesis-video-streams-producer-c.git
     GIT_TAG           v1.5.4
     PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
+    SOURCE_DIR        ${SOURCE_DIR}
     LIST_SEPARATOR    |
     CMAKE_ARGS        
       -DCMAKE_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX}
@@ -25,3 +29,6 @@ ExternalProject_Add(libkvsCommonLws-download
     BUILD_ALWAYS      TRUE
     TEST_COMMAND      ""
 )
+
+# Ensure the source directory is not deleted after the build
+set_property(TARGET libkvsCommonLws-download PROPERTY EP_SOURCE_DIR ${SOURCE_DIR})


### PR DESCRIPTION
*Issue #, if available:*

*What was changed?*
Added `SOURCE_DIR` field to keep the source files after the build has completed.

*Why was it changed?*
For debugging, the source files are required to step through the code.

*How was it changed?*

*What testing was done for the changes?*

Build the code with debug enabled: `cmake .. -DCMAKE_BUILD_TYPE=Debug`
Use the following sample launch.json to begin debugging in VS code [update `program` path as required]:
``` json
{
    // Use IntelliSense to learn about possible attributes.
    // Hover to view descriptions of existing attributes.
    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
    "version": "0.2.0",
    "configurations": [
        {
        "name": "(gdb) Launch",
        "type": "cppdbg",
        "request": "launch",
        "program": "/home/ubuntu/Projects/KVS/amazon-kinesis-video-streams-webrtc-sdk-c/build/samples/kvsWebrtcClientMaster",
        "args": ["********************"],
        "stopAtEntry": true,
        "cwd": "${fileDirname}",
        "environment": [
            { "name": "AWS_ACCESS_KEY_ID", "value": "********************" },
            { "name": "AWS_SECRET_ACCESS_KEY", "value": "********************" },
            { "name": "AWS_DEFAULT_REGION", "value": "********************" },
        ],
        "externalConsole": false,
        "MIMode": "gdb",
        "setupCommands": [
            {
                "description": "Enable pretty-printing for gdb",
                "text": "-enable-pretty-printing",
                "ignoreFailures": true
            },
            {
                "description": "Set Disassembly Flavor to Intel",
                "text": "-gdb-set disassembly-flavor intel",
                "ignoreFailures": true
            }
        ]
    }]
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
